### PR TITLE
Migrate SSWlib to submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SSWLib"]
+	path = SSWLib
+	url = https://github.com/WEKarnesky/sswlib

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Some notes about how to download a release and get started using the application
 ## Building From Source
 Development of this project currently requires the [NetBeans IDE](https://netbeans.apache.org/download/index.html).
 
-1. Clone this repository as well as [SSWlib](https://github.com/WEKarnesky/sswlib).
-2. Open the `SSW` project in NetBeans. You should get an error about `SSWlib` missing. Click Resolve to point it to the cloned `SSWlib` directory.
-3. Right click on the `SSW` project and go to the `Run` tab. Change the working directory to `./dist`.
+1. Clone this repository with `git clone --recursive https://github.com/WEKarnesky/solarisskunkwerks`.
+2. Open the project with NetBeans.
+3. To be able to run the application directly from the NetBeans IDE, right click on the SSW project and go to the Run tab, then change the working directory to `./dist`.
 4. Right click the `SSW` project and click `Build`. From now on you can launch the application from `./dist` with `java -jar SSW.jar` or from NetBeans with the `Run Main Project` menu.
 
 ## Contributing

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -5,6 +5,8 @@ javac.test.classpath=\
     ${build.classes.dir}:\
     ${libs.junit_4.classpath}:\
     ${libs.hamcrest.classpath}
+project.SSWlib=SSWLib
+reference.SSWlib.jar=${project.SSWlib}/dist/SSWlib.jar
 run.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}
@@ -40,7 +42,6 @@ jlink.launcher=false
 javac.deprecation=false
 application.vendor=ssw
 javadoc.additionalparam=
-reference.SSWlib.jar=${project.SSWlib}/dist/SSWlib.jar
 jnlp.signed=false
 jlink.launcher.name=SSW
 build.generated.sources.dir=${build.dir}/generated-sources
@@ -70,7 +71,6 @@ javadoc.version=false
 application.title=SSW
 javac.test.modulepath=\
     ${javac.modulepath}
-project.SSWlib=../SSWLib
 javac.external.vm=false
 debug.test.classpath=${run.test.classpath}
 javac.target=1.8

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,31 +1,13 @@
-annotation.processing.enabled=true
-annotation.processing.enabled.in.editor=false
-annotation.processing.processors.list=
-annotation.processing.run.all.processors=true
-endorsed.classpath=
-#Sat Jul 06 16:35:38 EDT 2019
+#Sat Jul 06 23:36:30 EDT 2019
 excludes=
-javac.external.vm=false
-javac.processorpath=\
-    ${javac.classpath}
-javac.test.classpath=\
-    ${javac.classpath}:\
-    ${build.classes.dir}:\
-    ${libs.junit.classpath}:\
-    ${libs.junit_4.classpath}:\
-    ${libs.hamcrest.classpath}
-javadoc.html5=false
-jlink.launcher=false
-jlink.launcher.name=SSW
-mkdist.disabled=false
-run.classpath=\
-    ${javac.classpath}:\
-    ${build.classes.dir}
+javac.test.classpath=${javac.classpath}\:${build.classes.dir}\:\:${libs.junit_4.classpath}\:${libs.hamcrest.classpath}
+run.classpath=${javac.classpath}\:${build.classes.dir}
+javac.processorpath=${javac.classpath}
 dist.javadoc.dir=${dist.dir}/javadoc
 jnlp.offline-allowed=false
 test.src.dir=test
-run.modulepath=\
-    ${javac.modulepath}
+run.modulepath=${javac.modulepath}
+annotation.processing.enabled=true
 jnlp.codebase.type=local
 build.sysclasspath=ignore
 debug.modulepath=${run.modulepath}
@@ -33,31 +15,34 @@ javac.compilerargs=
 javadoc.noindex=false
 javadoc.private=false
 javadoc.author=false
+endorsed.classpath=
 jnlp.codebase.url=file\:/home/justin/devel/SSW/dist
 main.class=ssw.Main
-junit.selected.version=4
+junit.selected.version=3
 source.encoding=UTF-8
 javac.source=1.8
 includes=**
 javadoc.use=true
 jar.compress=false
 javadoc.nonavbar=false
+annotation.processing.enabled.in.editor=false
 javadoc.notree=false
+annotation.processing.processors.list=
+jlink.launcher=false
 javac.deprecation=false
 application.vendor=ssw
 javadoc.additionalparam=
 reference.SSWlib.jar=${project.SSWlib}/dist/SSWlib.jar
 jnlp.signed=false
+jlink.launcher.name=SSW
 build.generated.sources.dir=${build.dir}/generated-sources
 javadoc.splitindex=true
 javac.processormodulepath=
 run.jvmargs=
 javadoc.encoding=${source.encoding}
-javac.classpath=\
-    ${libs.absolutelayout.classpath}:\
-    ${reference.SSWlib.jar}
-run.test.modulepath=\
-    ${javac.test.modulepath}
+javac.classpath=${libs.absolutelayout.classpath}\:${reference.SSWlib.jar}
+mkdist.disabled=false
+run.test.modulepath=${javac.test.modulepath}
 build.classes.excludes=**/*.java,**/*.form
 dist.jar=${dist.dir}/SSW.jar
 build.classes.dir=${build.dir}/classes
@@ -72,17 +57,17 @@ build.dir=build
 build.generated.dir=${build.dir}/generated
 javadoc.version=false
 application.title=SSW
-javac.test.modulepath=\
-    ${javac.modulepath}
+javac.test.modulepath=${javac.modulepath}
 project.SSWlib=../SSWLib
+javac.external.vm=false
 debug.test.classpath=${run.test.classpath}
 javac.target=1.8
 platform.active=default_platform
 manifest.file=manifest.mf
+javadoc.html5=false
 meta.inf.dir=${src.dir}/META-INF
-run.test.classpath=\
-    ${javac.test.classpath}:\
-    ${build.test.classes.dir}
+run.test.classpath=${javac.test.classpath}\:${build.test.classes.dir}
+annotation.processing.run.all.processors=true
 javac.modulepath=
 src.dir=src
 debug.classpath=${run.classpath}

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,12 +1,20 @@
 #Sat Jul 06 23:36:30 EDT 2019
 excludes=
-javac.test.classpath=${javac.classpath}\:${build.classes.dir}\:\:${libs.junit_4.classpath}\:${libs.hamcrest.classpath}
-run.classpath=${javac.classpath}\:${build.classes.dir}
-javac.processorpath=${javac.classpath}
+javac.test.classpath=\
+    ${javac.classpath}:\
+    ${build.classes.dir}:\
+    ${libs.junit_4.classpath}:\
+    ${libs.hamcrest.classpath}
+run.classpath=\
+    ${javac.classpath}:\
+    ${build.classes.dir}
+javac.processorpath=\
+    ${javac.classpath}
 dist.javadoc.dir=${dist.dir}/javadoc
 jnlp.offline-allowed=false
 test.src.dir=test
-run.modulepath=${javac.modulepath}
+run.modulepath=\
+    ${javac.modulepath}
 annotation.processing.enabled=true
 jnlp.codebase.type=local
 build.sysclasspath=ignore
@@ -40,9 +48,12 @@ javadoc.splitindex=true
 javac.processormodulepath=
 run.jvmargs=
 javadoc.encoding=${source.encoding}
-javac.classpath=${libs.absolutelayout.classpath}\:${reference.SSWlib.jar}
+javac.classpath=\
+    ${libs.absolutelayout.classpath}:\
+    ${reference.SSWlib.jar}
 mkdist.disabled=false
-run.test.modulepath=${javac.test.modulepath}
+run.test.modulepath=\
+    ${javac.test.modulepath}
 build.classes.excludes=**/*.java,**/*.form
 dist.jar=${dist.dir}/SSW.jar
 build.classes.dir=${build.dir}/classes
@@ -57,7 +68,8 @@ build.dir=build
 build.generated.dir=${build.dir}/generated
 javadoc.version=false
 application.title=SSW
-javac.test.modulepath=${javac.modulepath}
+javac.test.modulepath=\
+    ${javac.modulepath}
 project.SSWlib=../SSWLib
 javac.external.vm=false
 debug.test.classpath=${run.test.classpath}
@@ -66,7 +78,9 @@ platform.active=default_platform
 manifest.file=manifest.mf
 javadoc.html5=false
 meta.inf.dir=${src.dir}/META-INF
-run.test.classpath=${javac.test.classpath}\:${build.test.classes.dir}
+run.test.classpath=\
+    ${javac.test.classpath}:\
+    ${build.test.classes.dir}
 annotation.processing.run.all.processors=true
 javac.modulepath=
 src.dir=src


### PR DESCRIPTION
This PR migrates SSWLib to a git submodule and fixes the NetBeans project structure to automatically resolve it as a dependency. After this PR, one simply needs to clone SSW with `--recursive` and it will automatically pull in sswlib and be able to build in netbeans without any configuration.

Note that for now, until `develop` gets rebased with `master`, `git clone --recursive` won't work. In the mean time, clone master normally, check out the develop branch, and run `git submodule update --init --recursive` to fetch the SSWLib submodule.